### PR TITLE
Allow passing in arbitrary tcpdump arguments

### DIFF
--- a/macseen
+++ b/macseen
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+echo "Usage: $0 [tcpdump arguments]"
 echo "You may need to enter your password so TCPdump can connect to your adapater."
 sudo echo "Now with the fun bit!"
-sudo tcpdump -e -l -i en1 | ruby macseen.rb
+echo "Running: tcpdump -e -l $@"
+sudo tcpdump -e -l $@ | ruby macseen.rb

--- a/macseen.rb
+++ b/macseen.rb
@@ -26,7 +26,7 @@ def self.normal
 end
 
 while line = gets
-  timestamp, address, *_ = line.strip.split ' '
+  timestamp, address, _ = line.strip.split(' ', 3)
 
   time = Time.parse timestamp
 


### PR DESCRIPTION
Not everyone wants to capture off en1!

Also I can make it only watch for MACs that I care about.
